### PR TITLE
Adds SVG support to the Tikz content_processor.

### DIFF
--- a/lib/webgen/content_processor/tikz.rb
+++ b/lib/webgen/content_processor/tikz.rb
@@ -11,7 +11,6 @@ Webgen::Utils::ExternalCommand.ensure_available!('pdfcrop', '--version')
 Webgen::Utils::ExternalCommand.ensure_available!('gs', '-v')
 Webgen::Utils::ExternalCommand.ensure_available!('convert', '-version')
 Webgen::Utils::ExternalCommand.ensure_available!('identify', '-version')
-Webgen::Utils::ExternalCommand.ensure_available!('pdf2svg', '-v')
 
 module Webgen
   class ContentProcessor


### PR DESCRIPTION
The previous ImageMagick-based method of converting PDFs doesn't work that great with SVGs (at least on my machine). Now, it uses the `pdf2svg` that should be available on most major Linux distros as well as on macOS to generate SVGs.