### PR TITLE
Removes pdfcrop step in Tikz content_processor.

### DIFF
--- a/data/webgen/passive_sources/templates/tikz.template
+++ b/data/webgen/passive_sources/templates/tikz.template
@@ -1,7 +1,6 @@
 --- name:content pipeline:erb
 \nonstopmode
-\documentclass{standalone}
-\usepackage{tikz}
+\documentclass[tikz]{standalone}
 
 <% if context['content_processor.tikz.libraries'] %>
 \usetikzlibrary{<%= context['content_processor.tikz.libraries'].join(',') %>}

--- a/lib/webgen/content_processor/tikz.rb
+++ b/lib/webgen/content_processor/tikz.rb
@@ -7,7 +7,6 @@ require 'webgen/content_processor'
 require 'webgen/utils/external_command'
 
 Webgen::Utils::ExternalCommand.ensure_available!('pdflatex', '-v')
-Webgen::Utils::ExternalCommand.ensure_available!('pdfcrop', '--version')
 Webgen::Utils::ExternalCommand.ensure_available!('gs', '-v')
 Webgen::Utils::ExternalCommand.ensure_available!('convert', '-version')
 Webgen::Utils::ExternalCommand.ensure_available!('identify', '-version')
@@ -72,8 +71,6 @@ module Webgen
           raise Webgen::RenderError.new("Error while parsing TikZ picture commands with PDFLaTeX: #{errors}",
                                         'content_processor.tikz', context.dest_node, context.ref_node)
         end
-
-        execute("pdfcrop #{basename}.pdf #{basename}.pdf", cwd, context)
 
         if context['content_processor.tikz.transparent'] && ext =~ /\.png/i
           cmd = "gs -dSAFER -dBATCH -dNOPAUSE -r#{render_res} -sDEVICE=pngalpha -dGraphicsAlphaBits=4 " +


### PR DESCRIPTION
Switches to using `\documentclass[tikz]{standalone}`, which will automatically crop the resulting PDF along the margins of the Tikz picture, making the pdfcrop step unnecessary.