### PR TITLE
Adds support for other LaTeX engines for the Tikz content_processor.

### DIFF
--- a/lib/webgen/bundle/built-in/info.yaml
+++ b/lib/webgen/bundle/built-in/info.yaml
@@ -404,6 +404,20 @@ options:
         \tikz \draw (0,0) -- (0,2) -- (2,2);
         {tikz}
 
+  content_processor.tikz.engine:
+    summary: |
+      Specifies which LaTeX engine should be used. Default is pdflatex, but you may want to use
+      xelatex or lualatex if needed.
+    syntax: |
+      `pdflatex` or `lualatex` or `xelatex`
+    example:
+      config: |
+        content_processor.tikz.engine: lualatex
+      tag: |
+        {tikz:: {path: tikz.png, content_processor.tikz.engine: xelatex}}
+        \tikz \draw (0,0) -- (0,2) -- (2,2);
+        {tikz}
+
   content_processor.xmllint.options:
     summary: |
       Options passed to the `xmllint` command.

--- a/lib/webgen/bundle/built-in/init.rb
+++ b/lib/webgen/bundle/built-in/init.rb
@@ -112,6 +112,7 @@ option('content_processor.tikz.resolution', '72 72',) do |val|
 end
 option('content_processor.tikz.transparent', false, &true_or_false)
 option('content_processor.tikz.template', '/templates/tikz.template', &is_string)
+option('content_processor.tikz.engine', 'pdflatex', &is_string)
 
 content_processor.register('Xmllint')
 option('content_processor.xmllint.options', "--catalogs --noout --valid", &is_string)

--- a/lib/webgen/content_processor/tikz.rb
+++ b/lib/webgen/content_processor/tikz.rb
@@ -31,7 +31,7 @@ module Webgen
       def self.prepare_options(context)
         %w[content_processor.tikz.resolution content_processor.tikz.transparent
            content_processor.tikz.libraries content_processor.tikz.opts
-           content_processor.tikz.template].each do |opt|
+           content_processor.tikz.template content_processor.tikz.engine].each do |opt|
           context[opt] = context.content_node[opt] || context.website.config[opt]
         end
         context['data'] = context.content
@@ -66,10 +66,11 @@ module Webgen
       def self.compile(context, cwd, tex_file, basename, ext)
         render_res, output_res = context['content_processor.tikz.resolution'].split(' ')
 
+        engine = context['content_processor.tikz.engine']
         File.write(tex_file, context.content)
-        execute("pdflatex -shell-escape -interaction=nonstopmode -halt-on-error #{basename}.tex", cwd, context) do |_status, stdout, stderr|
+        execute("#{engine} -shell-escape -interaction=nonstopmode -halt-on-error #{basename}.tex", cwd, context) do |_status, stdout, stderr|
           errors = (stdout+stderr).scan(/^!(.*\n.*)/).join("\n")
-          raise Webgen::RenderError.new("Error while parsing TikZ picture commands with PDFLaTeX: #{errors}",
+          raise Webgen::RenderError.new("Error while parsing TikZ picture commands with #{engine}: #{errors}",
                                         'content_processor.tikz', context.dest_node, context.ref_node)
         end
 


### PR DESCRIPTION
Adds a new configuration option, `content_processor.tikz.engine`, which can be used to set the LaTeX engine to be used. By default, it still uses PDFLatex, but it can be set to XeLaTeX, LuaLaTeX, or any other installed LaTeX engine.

The advantage is that the newer engines have support for modern fonts, which might come in handy for some graphs.