### PR TITLE
Only read languages lines after `__END__`

### DIFF
--- a/lib/webgen/languages.rb
+++ b/lib/webgen/languages.rb
@@ -82,15 +82,22 @@ module Webgen
     def self.languages
       unless defined?(@@languages)
         @@languages = {}
-        started = nil
-        data = File.readlines(__FILE__).each do |l|
-          next if !started && (started = (l == '__END__'))
+
+        reached_data_lines = false
+        data_lines = File.readlines(__FILE__).drop_while do |line|
+          next false if reached_data_lines
+          reached_data_lines = true if line == "__END__\n"
+          true
+        end
+
+        data_lines.each do |l|
           data = l.chomp.split('|').collect {|f| f.empty? ? nil : f}
           lang = Language.new(data[0..2], data[3])
           @@languages[lang.code2chars] ||= lang unless lang.code2chars.nil?
           @@languages[lang.code3chars] ||= lang unless lang.code3chars.nil?
           @@languages[lang.code3chars_alternative] ||= lang unless lang.code3chars_alternative.nil?
         end
+
         @@languages.freeze
       end
       @@languages

--- a/test/webgen/test_languages.rb
+++ b/test/webgen/test_languages.rb
@@ -64,4 +64,12 @@ class TestLanguages < Minitest::Test
                  Webgen::LanguageManager.language_for_code(en))
   end
 
+  def test_loaded_languages
+    # Languages should only be loaded from DATA section, after __END__ line
+    path = Webgen::LanguageManager.method(:languages).source_location.first
+    ignored_line = File.readlines(path).first
+    keys = Webgen::LanguageManager.languages.keys
+    refute_includes keys, ignored_line
+    refute_includes keys, ignored_line.chomp
+  end
 end


### PR DESCRIPTION
The language list is directly embedded in the source code's DATA section, after `__END__`:

```ruby
# -*- encoding: utf-8 -*-

module Webgen
  # ...
end

__END__
aar||aa|Afar|afar
abk||ab|Abkhazian|abkhaze
ace|||Achinese|aceh
...
```

The lines prior to `__END__` were not filtered properly, polluting the languages hash with invalid languages. This fixes that.